### PR TITLE
Add OpenAI audio transcription adapter and routes

### DIFF
--- a/src/adapters/openai/v1/audio/transcriptions/adapter.ts
+++ b/src/adapters/openai/v1/audio/transcriptions/adapter.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 LMRouter Contributors
+
+import type {
+  Transcription,
+  TranscriptionCreateParamsBase,
+  TranscriptionStreamEvent,
+} from "openai/resources/audio/transcriptions";
+
+import { LMRouterAdapter } from "../../../../adapter.js";
+import { OpenAITranscriptionsOpenAIAdapter } from "./openai.js";
+import type { LMRouterConfigProvider } from "../../../../../utils/config.js";
+
+export type OpenAITranscriptionsAdapter = LMRouterAdapter<
+  TranscriptionCreateParamsBase,
+  {},
+  Transcription,
+  TranscriptionStreamEvent
+>;
+
+const adapters: Record<string, new () => OpenAITranscriptionsAdapter> = {
+  others: OpenAITranscriptionsOpenAIAdapter,
+};
+
+export class OpenAITranscriptionsAdapterFactory {
+  static getAdapter(
+    provider: LMRouterConfigProvider,
+  ): OpenAITranscriptionsAdapter {
+    if (!Object.keys(adapters).includes(provider.type)) {
+      return new adapters.others();
+    }
+    return new adapters[provider.type]();
+  }
+}

--- a/src/adapters/openai/v1/audio/transcriptions/openai.ts
+++ b/src/adapters/openai/v1/audio/transcriptions/openai.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 LMRouter Contributors
+
+import OpenAI from "openai";
+import { Stream } from "openai/core/streaming";
+import type {
+  Transcription,
+  TranscriptionCreateParamsBase,
+  TranscriptionCreateParamsNonStreaming,
+  TranscriptionCreateParamsStreaming,
+  TranscriptionStreamEvent,
+} from "openai/resources/audio/transcriptions";
+
+import type { OpenAITranscriptionsAdapter } from "./adapter.js";
+import type { LMRouterApiCallUsage } from "../../../../../utils/billing.js";
+import type { LMRouterConfigProvider } from "../../../../../utils/config.js";
+
+export class OpenAITranscriptionsOpenAIAdapter
+  implements OpenAITranscriptionsAdapter
+{
+  usage?: LMRouterApiCallUsage;
+
+  getClient(provider: LMRouterConfigProvider): OpenAI {
+    return new OpenAI({
+      baseURL: provider.base_url,
+      apiKey: provider.api_key,
+      defaultHeaders: {
+        "HTTP-Referer": "https://lmrouter.com/",
+        "X-Title": "LMRouter",
+      },
+    });
+  }
+
+  async sendRequest(
+    provider: LMRouterConfigProvider,
+    request: TranscriptionCreateParamsBase,
+    options?: {},
+  ): Promise<Transcription> {
+    const openai = this.getClient(provider);
+    const transcription = await openai.audio.transcriptions.create(
+      request as TranscriptionCreateParamsNonStreaming,
+    );
+    this.usage = {
+      input:
+        transcription.usage?.type === "tokens"
+          ? transcription.usage.input_tokens -
+            (transcription.usage.input_token_details?.audio_tokens ?? 0)
+          : 0,
+      input_audio:
+        transcription.usage?.type === "tokens"
+          ? (transcription.usage.input_token_details?.audio_tokens ?? 0)
+          : 0,
+      input_audio_time:
+        transcription.usage?.type === "duration"
+          ? transcription.usage.seconds
+          : 0,
+      output:
+        transcription.usage?.type === "tokens"
+          ? transcription.usage.output_tokens
+          : 0,
+      request: 1,
+    };
+    return transcription;
+  }
+
+  async sendRequestStreaming(
+    provider: LMRouterConfigProvider,
+    request: TranscriptionCreateParamsBase,
+    options?: {},
+  ): Promise<AsyncGenerator<TranscriptionStreamEvent>> {
+    const openai = this.getClient(provider);
+    const transcription = await openai.audio.transcriptions.create(
+      request as TranscriptionCreateParamsStreaming,
+    );
+    return async function* (this: OpenAITranscriptionsOpenAIAdapter) {
+      for await (const chunk of transcription as Stream<TranscriptionStreamEvent>) {
+        if (chunk.type === "transcript.text.done") {
+          this.usage = {
+            input:
+              (chunk.usage?.input_tokens ?? 0) -
+              (chunk.usage?.input_token_details?.audio_tokens ?? 0),
+            input_audio: chunk.usage?.input_token_details?.audio_tokens ?? 0,
+            output: chunk.usage?.output_tokens ?? 0,
+            request: 1,
+          };
+        }
+        yield chunk;
+      }
+    }.bind(this)();
+  }
+}

--- a/src/routes/v1/openai/v1.ts
+++ b/src/routes/v1/openai/v1.ts
@@ -4,6 +4,7 @@
 import { Hono } from "hono";
 
 import type { ContextEnv } from "../../../types/hono.js";
+import audioRouter from "./v1/audio.js";
 import chatRouter from "./v1/chat.js";
 import embeddingsRouter from "./v1/embeddings.js";
 import imagesRouter from "./v1/images.js";
@@ -12,6 +13,7 @@ import responsesRouter from "./v1/responses.js";
 
 const openaiV1Router = new Hono<ContextEnv>();
 
+openaiV1Router.route("/audio", audioRouter);
 openaiV1Router.route("/chat", chatRouter);
 openaiV1Router.route("/embeddings", embeddingsRouter);
 openaiV1Router.route("/images", imagesRouter);

--- a/src/routes/v1/openai/v1/audio.ts
+++ b/src/routes/v1/openai/v1/audio.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 LMRouter Contributors
+
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import type { TranscriptionCreateParamsBase } from "openai/resources/audio/transcriptions";
+
+import { OpenAITranscriptionsAdapterFactory } from "../../../../adapters/openai/v1/audio/transcriptions/adapter.js";
+import { requireAuth } from "../../../../middlewares/auth.js";
+import { ensureBalance } from "../../../../middlewares/billing.js";
+import { parseModel } from "../../../../middlewares/model.js";
+import type { ContextEnv } from "../../../../types/hono.js";
+import { recordApiCall } from "../../../../utils/billing.js";
+import { TimeKeeper } from "../../../../utils/chrono.js";
+import { iterateModelProviders } from "../../../../utils/utils.js";
+
+const audioRouter = new Hono<ContextEnv>();
+
+audioRouter.use(requireAuth(), ensureBalance, parseModel);
+
+audioRouter.post("/transcriptions", async (c) => {
+  const formData = await c.req.formData();
+  const body: Record<string, any> = {};
+  for (const [key, value] of formData.entries()) {
+    if (key === "include[]") {
+      if (!Array.isArray(body.include)) {
+        body.include = [];
+      }
+      body.include.push(value);
+    } else if (key === "timestamp_granularities[]") {
+      if (!Array.isArray(body.timestamp_granularities)) {
+        body.timestamp_granularities = [];
+      }
+      body.timestamp_granularities.push(value);
+    } else {
+      body[key] = value;
+    }
+  }
+
+  if (body.response_format && body.response_format !== "json") {
+    return c.json(
+      {
+        error: {
+          message: `Response format ${body.response_format} is not supported`,
+        },
+      },
+      400,
+    );
+  }
+
+  return await iterateModelProviders(c, async (providerCfg, provider) => {
+    const reqBody = { ...body } as TranscriptionCreateParamsBase;
+    reqBody.model = providerCfg.model;
+
+    const adapter = OpenAITranscriptionsAdapterFactory.getAdapter(provider);
+    const timeKeeper = new TimeKeeper();
+    timeKeeper.record();
+    if ((reqBody.stream as unknown as string) !== "true") {
+      const transcription = await adapter.sendRequest(provider, reqBody);
+      timeKeeper.record();
+      await recordApiCall(
+        c,
+        providerCfg.provider,
+        200,
+        timeKeeper.timestamps(),
+        adapter.usage,
+        providerCfg.pricing,
+      );
+      return c.json(transcription);
+    }
+
+    const s = await adapter.sendRequestStreaming(provider, reqBody);
+    return streamSSE(c, async (stream) => {
+      for await (const chunk of s) {
+        timeKeeper.record();
+        await stream.writeSSE({
+          data: JSON.stringify(chunk),
+        });
+      }
+      await stream.writeSSE({
+        data: "[DONE]",
+      });
+      await recordApiCall(
+        c,
+        providerCfg.provider,
+        200,
+        timeKeeper.timestamps(),
+        adapter.usage,
+        providerCfg.pricing,
+      );
+    });
+  });
+});
+
+export default audioRouter;

--- a/src/utils/billing.ts
+++ b/src/utils/billing.ts
@@ -27,6 +27,7 @@ export interface LMRouterApiCallUsage {
   input?: number;
   input_image?: number;
   input_audio?: number;
+  input_audio_time?: number;
   output?: number;
   output_audio?: number;
   image?: number;
@@ -61,6 +62,11 @@ export const calculateCost = (
       new Decimal(usage.input_audio ?? 0)
         .mul(pricing.input_audio ?? 0)
         .dividedBy(1000000),
+    );
+    cost = cost.plus(
+      new Decimal(usage.input_audio_time ?? 0)
+        .mul(pricing.input_audio_time ?? 0)
+        .dividedBy(60),
     );
     cost = cost.plus(
       new Decimal(usage.output ?? 0)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -66,6 +66,7 @@ export interface LMRouterConfigModelProviderPricingFixed {
   input?: number;
   input_image?: number;
   input_audio?: number;
+  input_audio_time?: number;
   output?: number;
   output_audio?: number;
   image?: number;


### PR DESCRIPTION
- Introduced the OpenAITranscriptionsAdapter and OpenAITranscriptionsOpenAIAdapter classes to handle audio transcription requests.
- Implemented a new audio router with endpoints for transcriptions, including support for both standard and streaming requests.
- Enhanced billing tracking by incorporating input audio time into the API call usage metrics.
- Updated the main OpenAI router to include the new audio route for improved API organization.